### PR TITLE
Поправил верстку BottomNavigationView в соответствии с макетом

### DIFF
--- a/app/src/main/res/color/bottom_nav_item_color.xml
+++ b/app/src/main/res/color/bottom_nav_item_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/gray400" android:state_checked="false" />
+    <item android:color="@color/blue" android:state_checked="true" />
+</selector>

--- a/app/src/main/res/layout/activity_root.xml
+++ b/app/src/main/res/layout/activity_root.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.root.RootActivity"
-    android:background="@color/bottom_navigation_view_background">
+    android:background="@color/bottom_navigation_view_background"
+    tools:context=".ui.root.RootActivity">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/rootFragmentContainerView"
@@ -14,20 +13,37 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:defaultNavHost="true"
-        app:navGraph="@navigation/nav_graph"
-        app:layout_constraintBottom_toTopOf="@+id/bottomNavigationView"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNavigationDivider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+
+    <!-- Полоса-разделитель сверху меню -->
+    <View
+        android:id="@+id/bottomNavigationDivider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:background="@color/gray100"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavigationView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigationView"
+        style="@style/BottomNavigationMenu"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/bottom_navigation_view_background"
-        app:menu="@menu/bottom_navigation_view"
+        app:itemIconTint="@color/bottom_nav_item_color"
+        app:itemPaddingBottom="@dimen/space8"
+        app:itemPaddingTop="@dimen/space9"
+        app:itemTextAppearanceActive="@style/BottomNavMenuText"
+        app:itemTextAppearanceInactive="@style/BottomNavMenuText"
+        app:itemTextColor="@color/bottom_nav_item_color"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/bottom_navigation_view" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Bottom Navigation -->
+    <!-- padding_top -->
+    <dimen name="space9">9dp</dimen>
+
+    <!-- padding_bottom -->
+    <dimen name="space8">8dp</dimen>
+
+    <!-- menu item text size -->
+    <dimen name="textSizeMedium">12sp</dimen>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="BottomNavigationMenu" parent="Widget.MaterialComponents.BottomNavigationView" />
+
+    <style name="BottomNavMenuText">
+        <item name="android:fontFamily">@font/ys_display_regular</item>
+        <item name="android:textSize">@dimen/textSizeMedium</item>
+    </style>
+</resources>


### PR DESCRIPTION
Первый ПР коряво вышел - вот новый. 
Стиль для меню унаследовал от MaterialComponents, т.к. Material3 (тема приложения) не позволяет уменьшить высоту bottom navigation view без костылей